### PR TITLE
Setting of LLM judge model in .env + option for manual LLM judge prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ python scripts/evaluate_retrieval.py
 ## Environment Variables
 
 Configure your `.env` file with:
-- `MODEL_NAME`: LLM model (e.g., `openai/gpt-4`, `anthropic/claude-3-haiku-20240307`)
+- `MODEL_NAME`: LLM model for chatbot (e.g., `openai/gpt-5-chat-latest`, `anthropic/claude-3-sonnet-20240229`)
+- `MODEL_NAME_JUDGE`: LLM model for judge, which can be smaller than the chatbot model (e.g., `openai/gpt-5-mini`, `anthropic/claude-3-haiku-20240307`)
 - API keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.
 
 See [LiteLLM docs](https://docs.litellm.ai/docs/providers) for supported providers.

--- a/env.example
+++ b/env.example
@@ -1,6 +1,10 @@
 # Copy this file to `.env` and fill in your credentials.
 
-MODEL_NAME=openai/gpt-4.1-nano
+# Model used for the chat Recipe Bot
+MODEL_NAME=openai/gpt-4.1-mini
+
+# Model used for the LLM judge (use a cheaper model for judge evaluation)
+MODEL_NAME_JUDGE=openai/gpt-4.1-nano
 
 # Example API keys
 # OPENAI_API_KEY=

--- a/homeworks/hw3/README.md
+++ b/homeworks/hw3/README.md
@@ -50,8 +50,9 @@ Choose the option that best fits your learning goals and available time!
 - **Option 2**: Use our provided `raw_traces.csv`, then label a subset
 
 ### Step 2: Split Your Labeled Data *[Option 3 starts here]*
+
 - Divide your labeled set into Train (~10-20%), Dev (~40%), and Test (~40-50%)
-- **Option 3**: Use our provided `labeled_traces.csv` (has 150 queries, which is > 100 but we provide more for demonstration purposes) and split it
+- **Option 3**: Use our provided `labeled_traces.csv` and split it
 
 ### Step 3: Develop Your LLM-as-Judge Prompt *[All options continue from here]*
 Craft a clear prompt with:

--- a/homeworks/hw3/README.md
+++ b/homeworks/hw3/README.md
@@ -9,6 +9,7 @@ We'll provide ~2000 starter Recipe Bot traces and detailed criteria for this fai
 **Alternatively**, you can choose a different Recipe Bot failure mode you identified in HW2/Chapter 3, but you'll need to define criteria and generate/source all your own traces.
 
 ## Tools You'll Use
+
 - Your preferred LLM (for crafting the judge)
 - Your critical thinking & prompt engineering skills!
 - The `judgy` Python library: [github.com/ai-evals-course/judgy](https://github.com/ai-evals-course/judgy)
@@ -18,14 +19,18 @@ We'll provide ~2000 starter Recipe Bot traces and detailed criteria for this fai
 You have three options for how much of the pipeline to implement yourself:
 
 ### Option 1: Full Implementation (Most Learning)
+
 Start from scratch and implement the complete pipeline:
+
 - Generate your own Recipe Bot traces
 - Label your own data
 - Build the entire evaluation workflow
 - **Learning**: Complete end-to-end experience with LLM-as-Judge methodology
 
 ### Option 2: Start with Raw Traces (Medium Implementation)
+
 Use our provided `raw_traces.csv` (~2400 traces) and focus on the evaluation:
+
 - Skip trace generation, start with labeling
 - Implement judge development and evaluation
 - Focus on the core LLM-as-Judge workflow
@@ -33,7 +38,9 @@ Use our provided `raw_traces.csv` (~2400 traces) and focus on the evaluation:
 - **Note**: Our traces were generated using `dietary_queries.csv` - 60 moderate to challenging edge queries we crafted
 
 ### Option 3: Start with Labeled Data (Judge Development Focus)
-Use our provided `labeled_traces.csv` (150 labeled examples):
+
+Use our provided `labeled_traces.csv` (101 labeled examples):
+
 - Skip trace generation and labeling
 - Focus on judge prompt engineering and evaluation
 - Implement the statistical correction workflow
@@ -44,6 +51,7 @@ Choose the option that best fits your learning goals and available time!
 ## Assignment Steps: From Labels to Confident Measurement 📊
 
 ### Step 1: Get & Label Your Data (Crucial!) *[Option 1 & 2 start here]*
+
 - **If using our "Dietary Adherence" task**: Manually label a subset of the provided traces (e.g., 100-200 examples) as "Pass" or "Fail" based on the provided criteria. This is your ground truth!
 - **If using your own failure mode**: Generate/collect and label your traces.
 - **Option 1**: Generate your own traces first, then label them. Feel free to use data/dietary_queries.csv as a starting point for queries to generate traces with.
@@ -55,23 +63,29 @@ Choose the option that best fits your learning goals and available time!
 - **Option 3**: Use our provided `labeled_traces.csv` and split it
 
 ### Step 3: Develop Your LLM-as-Judge Prompt *[All options continue from here]*
+
 Craft a clear prompt with:
+
 - The specific task/criterion
 - Precise Pass/Fail definitions
 - 2-3 clear few-shot examples (input, Recipe Bot output, desired judge reasoning & Pass/Fail label) taken from your Train set
 - The structured output format you expect from the judge (e.g., JSON with reasoning and answer)
 
 ### Step 4: Refine & Validate Your Judge
+
 - Iteratively test and refine your judge prompt using your Dev set
 - Measure and report your judge's TPR & TNR on the Dev set during refinement
 - Once finalized, report the judge's final TPR & TNR on your Test set
 
 ### Step 5: Measure on "New" Traces
+
 - Run your finalized judge over a larger set of "new" Recipe Bot traces (e.g., 500-1000 more from the provided set, or newly generated ones)
 - This simulates evaluating production data
 
 ### Step 6: Report Results with judgy
+
 Report:
+
 - The raw pass rate (p_obs) from your judge on the new traces
 - The corrected true success rate (θ̂)
 - The 95% Confidence Interval (CI) for θ
@@ -82,6 +96,7 @@ Report:
 **Definition**: When a user requests a recipe with specific dietary restrictions or preferences, the Recipe Bot should provide a recipe that actually meets those restrictions and preferences.
 
 **Examples**:
+
 - ✅ Pass: User asks for "vegan pasta recipe" → Bot provides pasta with nutritional yeast instead of parmesan
 - ❌ Fail: User asks for "vegan pasta recipe" → Bot suggests using honey as a sweetener (honey isn't vegan)
 - ✅ Pass: User asks for "gluten-free bread" → Bot provides recipe using almond flour and xanthan gum
@@ -90,6 +105,7 @@ Report:
 - ❌ Fail: User asks for "keto dinner" → Bot includes sweet potato as a "healthy carb" (too high-carb for keto)
 
 ### Dietary Restriction Definitions (for reference; taken from OpenAI o4):
+
 - **Vegan**: No animal products (meat, dairy, eggs, honey, etc.)
 - **Vegetarian**: No meat or fish, but dairy and eggs are allowed
 - **Gluten-free**: No wheat, barley, rye, or other gluten-containing grains
@@ -110,21 +126,25 @@ Report:
 ## Sample Challenging Queries
 
 **Contradictory Requests:**
+
 - "I'm vegan but I really want to make something with honey - is there a good substitute?"
 - "I want a cheeseburger but I'm dairy-free and vegetarian"
 
 **Ambiguous Preferences:**
+
 - "Something not too carb-y for dinner"
 - "Something keto-ish but not super strict"
 - "Dairy-free but cheese is okay sometimes"
 
 ## Key Metrics to Understand
+
 - **True Positive Rate (TPR)**: How often the judge correctly identifies adherent recipes
 - **True Negative Rate (TNR)**: How often the judge correctly identifies non-adherent recipes  
 - **Corrected Success Rate**: True adherence rate accounting for judge errors
 - **95% Confidence Interval**: Range for the corrected success rate
 
 ## Deliverables
+
 1. **Your labeled dataset** with train/dev/test splits
 2. **Your final judge prompt** with few-shot examples
 3. **Judge performance metrics** (TPR/TNR on test set)
@@ -132,6 +152,7 @@ Report:
 5. **Brief analysis** (1-2 paragraphs) interpreting your results
 
 ## Reference Implementation
+
 This repository contains a complete reference implementation showing one approach to this assignment. You can:
 - **Study the code structure** to understand the workflow
 - **Use our provided data** as a starting point
@@ -140,6 +161,7 @@ This repository contains a complete reference implementation showing one approac
 The reference implementation uses automated labeling with GPT-4o for demonstration purposes. **In practice, you should manually review and correct all labels** for reliable evaluation.
 
 ### Reference Implementation Structure
+
 ```
 homeworks/hw3/
 ├── scripts/
@@ -163,6 +185,7 @@ homeworks/hw3/
 ```
 
 ### How to Run the Reference Implementation
+
 ```bash
 # From project root directory
 cd homeworks/hw3
@@ -187,6 +210,7 @@ python scripts/run_full_evaluation.py
 ```
 
 ### Our Final Results
+
 Here were our final results from running the complete reference implementation:
 
 ```bash
@@ -200,6 +224,7 @@ Correction Applied: 0.069 (6.9 percentage points)
 This suggests the Recipe Bot has strong dietary adherence (92.6% corrected success rate), with the judge initially underestimating performance due to false negatives. The 6.9 percentage point correction indicates our judge had some bias that was successfully accounted for using the judgy library.
 
 ## Setup
+
 1. Install dependencies: `pip install -r requirements.txt` (from project root)
 2. Configure your LLM API keys in `.env`
 3. Choose your failure mode and begin labeling!

--- a/homeworks/hw3/hw3_walkthrough.ipynb
+++ b/homeworks/hw3/hw3_walkthrough.ipynb
@@ -46,7 +46,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generate Traces"
+    "## Step 1a: Generate Traces\n",
+    "\n",
+    "> NOTE: Homework assignment _option 1_ starts here."
    ]
   },
   {
@@ -108,7 +110,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Label the Data"
+    "## Step 1b: Label the Data\n",
+    "\n",
+    "> NOTE: Homework assignment _option 2_ starts here."
    ]
   },
   {
@@ -180,7 +184,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Split Your Labeled Data\n",
+    "## Step 2: Split Your Labeled Data\n",
+    "\n",
+    "> NOTE: Homework assignment _option 3_ starts here.\n",
     "\n",
     "In every data driven approach you should split your data in different sets.\n",
     "\n",
@@ -396,14 +402,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Develop Your LLM-as-Judge Prompt"
+    "## Step 3: Develop Your LLM-as-Judge Prompt"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `develop_judge.py` script creates a judge prompt with few-shot examples from the training set.\n",
+    "The `develop_judge.py` script uses an existing judge prompt and adds some few-shot examples from the training set.\n",
     "\n",
     "This script chooses few-shot examples randomly to create a demonstration of what a prompt might look like.  During the process I recommend:\n",
     "\n",

--- a/homeworks/hw3/results/dev_predictions.json
+++ b/homeworks/hw3/results/dev_predictions.json
@@ -2,321 +2,361 @@
   {
     "trace_id": "49_29",
     "true_label": "PASS",
-    "predicted_label": "PASS",
+    "predicted_label": "ERROR",
     "query": "I'm flexitarian leaning vegan",
     "dietary_restriction": "vegan",
-    "success": true
-  },
-  {
-    "trace_id": "7_8",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "I want to make a birthday cake but I'm diabetic. Something that still tastes good?",
-    "dietary_restriction": "diabetic-friendly",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
     "trace_id": "42_37",
     "true_label": "FAIL",
-    "predicted_label": "FAIL",
+    "predicted_label": "ERROR",
     "query": "I want something light but filling",
     "dietary_restriction": "low-carb",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "48_27",
-    "true_label": "FAIL",
-    "predicted_label": "PASS",
-    "query": "Gluten-light recipe - I'm not celiac just sensitive",
-    "dietary_restriction": "gluten-free",
-    "success": true
-  },
-  {
-    "trace_id": "55_3",
+    "trace_id": "7_8",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "I'm pescatarian but shellfish makes me sick",
-    "dietary_restriction": "pescatarian",
-    "success": true
-  },
-  {
-    "trace_id": "48_34",
-    "true_label": "FAIL",
-    "predicted_label": "PASS",
-    "query": "Gluten-light recipe - I'm not celiac just sensitive",
-    "dietary_restriction": "gluten-free",
-    "success": true
-  },
-  {
-    "trace_id": "37_33",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Sugar-free dessert that doesn't taste like sadness",
-    "dietary_restriction": "sugar-free",
-    "success": true
-  },
-  {
-    "trace_id": "47_8",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Dairy-free but cheese is okay sometimes",
-    "dietary_restriction": "dairy-free",
-    "success": true
-  },
-  {
-    "trace_id": "30_15",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Keto meal that doesn't make me feel gross",
-    "dietary_restriction": "keto",
-    "success": true
-  },
-  {
-    "trace_id": "39_17",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Something not too carb-y for dinner",
-    "dietary_restriction": "low-carb",
-    "success": true
-  },
-  {
-    "trace_id": "38_36",
-    "true_label": "FAIL",
-    "predicted_label": "FAIL",
-    "query": "I don't like vegetables but I want to eat healthy",
-    "dietary_restriction": "vegetarian",
-    "success": true
-  },
-  {
-    "trace_id": "28_28",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Halal pasta recipe - is that even a thing?",
-    "dietary_restriction": "halal",
-    "success": true
-  },
-  {
-    "trace_id": "9_25",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Raw vegan salad that doesn't taste like grass",
-    "dietary_restriction": "raw vegan",
-    "success": true
-  },
-  {
-    "trace_id": "38_22",
-    "true_label": "FAIL",
-    "predicted_label": "FAIL",
-    "query": "I don't like vegetables but I want to eat healthy",
-    "dietary_restriction": "vegetarian",
-    "success": true
-  },
-  {
-    "trace_id": "22_7",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "I'm diabetic but I want to make a fruit cake for Christmas. My grandmother's recipe has tons of sugar and dried fruit but it's tradition and I can't just skip it this year. Is there any way to modify it so I can still participate in the family tradition without spiking my blood sugar?",
+    "predicted_label": "ERROR",
+    "query": "I want to make a birthday cake but I'm diabetic. Something that still tastes good?",
     "dietary_restriction": "diabetic-friendly",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
     "trace_id": "22_27",
     "true_label": "PASS",
-    "predicted_label": "PASS",
+    "predicted_label": "ERROR",
     "query": "I'm diabetic but I want to make a fruit cake for Christmas. My grandmother's recipe has tons of sugar and dried fruit but it's tradition and I can't just skip it this year. Is there any way to modify it so I can still participate in the family tradition without spiking my blood sugar?",
     "dietary_restriction": "diabetic-friendly",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "53_11",
+    "trace_id": "37_33",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Kosher dessert for Passover",
-    "dietary_restriction": "kosher",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "Sugar-free dessert that doesn't taste like sadness",
+    "dietary_restriction": "sugar-free",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "45_6",
+    "trace_id": "47_8",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Something keto-ish but not super strict",
-    "dietary_restriction": "keto",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "Dairy-free but cheese is okay sometimes",
+    "dietary_restriction": "dairy-free",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "15_12",
+    "trace_id": "55_3",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "I'm on keto but I'm craving something sweet. Help?",
-    "dietary_restriction": "keto",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "I'm pescatarian but shellfish makes me sick",
+    "dietary_restriction": "pescatarian",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "46_15",
+    "trace_id": "48_27",
     "true_label": "FAIL",
-    "predicted_label": "FAIL",
-    "query": "I avoid processed foods but I'm lazy",
-    "dietary_restriction": "paleo",
-    "success": true
-  },
-  {
-    "trace_id": "15_31",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "I'm on keto but I'm craving something sweet. Help?",
-    "dietary_restriction": "keto",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "Gluten-light recipe - I'm not celiac just sensitive",
+    "dietary_restriction": "gluten-free",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
     "trace_id": "16_19",
     "true_label": "PASS",
-    "predicted_label": "PASS",
+    "predicted_label": "ERROR",
     "query": "Vegetarian curry but I don't eat onions or garlic for religious reasons",
     "dietary_restriction": "vegetarian",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "42_1",
-    "true_label": "FAIL",
-    "predicted_label": "FAIL",
-    "query": "I want something light but filling",
-    "dietary_restriction": "low-carb",
-    "success": true
-  },
-  {
-    "trace_id": "16_36",
+    "trace_id": "45_6",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Vegetarian curry but I don't eat onions or garlic for religious reasons",
-    "dietary_restriction": "vegetarian",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "Something keto-ish but not super strict",
+    "dietary_restriction": "keto",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "34_6",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Vegetarian meal that has enough protein for my bodybuilder boyfriend",
-    "dietary_restriction": "vegetarian",
-    "success": true
-  },
-  {
-    "trace_id": "47_3",
-    "true_label": "PASS",
-    "predicted_label": "FAIL",
-    "query": "Dairy-free but cheese is okay sometimes",
-    "dietary_restriction": "dairy-free",
-    "success": true
-  },
-  {
-    "trace_id": "51_31",
+    "trace_id": "46_15",
     "true_label": "FAIL",
-    "predicted_label": "FAIL",
-    "query": "I eat pretty clean most of the time",
-    "dietary_restriction": "whole30",
-    "success": true
-  },
-  {
-    "trace_id": "46_3",
-    "true_label": "FAIL",
-    "predicted_label": "FAIL",
+    "predicted_label": "ERROR",
     "query": "I avoid processed foods but I'm lazy",
     "dietary_restriction": "paleo",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "53_31",
+    "trace_id": "22_7",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Kosher dessert for Passover",
-    "dietary_restriction": "kosher",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "I'm diabetic but I want to make a fruit cake for Christmas. My grandmother's recipe has tons of sugar and dried fruit but it's tradition and I can't just skip it this year. Is there any way to modify it so I can still participate in the family tradition without spiking my blood sugar?",
+    "dietary_restriction": "diabetic-friendly",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "39_40",
+    "trace_id": "39_17",
     "true_label": "PASS",
-    "predicted_label": "PASS",
+    "predicted_label": "ERROR",
     "query": "Something not too carb-y for dinner",
     "dietary_restriction": "low-carb",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "38_36",
+    "true_label": "FAIL",
+    "predicted_label": "ERROR",
+    "query": "I don't like vegetables but I want to eat healthy",
+    "dietary_restriction": "vegetarian",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "48_34",
+    "true_label": "FAIL",
+    "predicted_label": "ERROR",
+    "query": "Gluten-light recipe - I'm not celiac just sensitive",
+    "dietary_restriction": "gluten-free",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
     "trace_id": "48_22",
     "true_label": "FAIL",
-    "predicted_label": "PASS",
+    "predicted_label": "ERROR",
     "query": "Gluten-light recipe - I'm not celiac just sensitive",
     "dietary_restriction": "gluten-free",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "32_12",
+    "trace_id": "16_36",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Gluten-free birthday cake for my 5-year-old who has celiac but all her friends will be eating regular cake and I don't want her to feel left out",
-    "dietary_restriction": "gluten-free",
-    "success": true
-  },
-  {
-    "trace_id": "43_28",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Comfort food that won't make me feel guilty",
+    "predicted_label": "ERROR",
+    "query": "Vegetarian curry but I don't eat onions or garlic for religious reasons",
     "dietary_restriction": "vegetarian",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "19_3",
+    "trace_id": "30_15",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Vegan protein smoothie that doesn't taste chalky",
-    "dietary_restriction": "vegan",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "Keto meal that doesn't make me feel gross",
+    "dietary_restriction": "keto",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "32_33",
-    "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Gluten-free birthday cake for my 5-year-old who has celiac but all her friends will be eating regular cake and I don't want her to feel left out",
-    "dietary_restriction": "gluten-free",
-    "success": true
+    "trace_id": "51_31",
+    "true_label": "FAIL",
+    "predicted_label": "ERROR",
+    "query": "I eat pretty clean most of the time",
+    "dietary_restriction": "whole30",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "18_30",
+    "trace_id": "9_25",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "Low-sodium soup recipe - my doctor says I need to cut back",
-    "dietary_restriction": "low-sodium",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "Raw vegan salad that doesn't taste like grass",
+    "dietary_restriction": "raw vegan",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "8_8",
+    "trace_id": "15_31",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "My kid needs a nut-free cookie recipe for school but she's super picky and only likes chocolate",
-    "dietary_restriction": "nut-free",
-    "success": true
+    "predicted_label": "ERROR",
+    "query": "I'm on keto but I'm craving something sweet. Help?",
+    "dietary_restriction": "keto",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
-    "trace_id": "17_35",
+    "trace_id": "38_22",
+    "true_label": "FAIL",
+    "predicted_label": "ERROR",
+    "query": "I don't like vegetables but I want to eat healthy",
+    "dietary_restriction": "vegetarian",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "47_3",
     "true_label": "PASS",
-    "predicted_label": "PASS",
-    "query": "I want paleo bread but every recipe I've tried is terrible",
+    "predicted_label": "ERROR",
+    "query": "Dairy-free but cheese is okay sometimes",
+    "dietary_restriction": "dairy-free",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "53_11",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Kosher dessert for Passover",
+    "dietary_restriction": "kosher",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "46_3",
+    "true_label": "FAIL",
+    "predicted_label": "ERROR",
+    "query": "I avoid processed foods but I'm lazy",
     "dietary_restriction": "paleo",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "34_6",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Vegetarian meal that has enough protein for my bodybuilder boyfriend",
+    "dietary_restriction": "vegetarian",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "28_28",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Halal pasta recipe - is that even a thing?",
+    "dietary_restriction": "halal",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "53_31",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Kosher dessert for Passover",
+    "dietary_restriction": "kosher",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "39_40",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Something not too carb-y for dinner",
+    "dietary_restriction": "low-carb",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "15_12",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "I'm on keto but I'm craving something sweet. Help?",
+    "dietary_restriction": "keto",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "42_1",
+    "true_label": "FAIL",
+    "predicted_label": "ERROR",
+    "query": "I want something light but filling",
+    "dietary_restriction": "low-carb",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
     "trace_id": "10_9",
     "true_label": "PASS",
-    "predicted_label": "PASS",
+    "predicted_label": "ERROR",
     "query": "I'm pescatarian but I hate fish. Can you give me a seafood pasta recipe?",
     "dietary_restriction": "pescatarian",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "43_28",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Comfort food that won't make me feel guilty",
+    "dietary_restriction": "vegetarian",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "8_8",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "My kid needs a nut-free cookie recipe for school but she's super picky and only likes chocolate",
+    "dietary_restriction": "nut-free",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "32_33",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Gluten-free birthday cake for my 5-year-old who has celiac but all her friends will be eating regular cake and I don't want her to feel left out",
+    "dietary_restriction": "gluten-free",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "32_12",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Gluten-free birthday cake for my 5-year-old who has celiac but all her friends will be eating regular cake and I don't want her to feel left out",
+    "dietary_restriction": "gluten-free",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "17_35",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "I want paleo bread but every recipe I've tried is terrible",
+    "dietary_restriction": "paleo",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "19_3",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Vegan protein smoothie that doesn't taste chalky",
+    "dietary_restriction": "vegan",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+  },
+  {
+    "trace_id": "18_30",
+    "true_label": "PASS",
+    "predicted_label": "ERROR",
+    "query": "Low-sodium soup recipe - my doctor says I need to cut back",
+    "dietary_restriction": "low-sodium",
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   },
   {
     "trace_id": "35_15",
     "true_label": "PASS",
-    "predicted_label": "PASS",
+    "predicted_label": "ERROR",
     "query": "Paleo breakfast that I can eat in the car on my commute",
     "dietary_restriction": "paleo",
-    "success": true
+    "success": false,
+    "error": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
   }
 ]

--- a/homeworks/hw3/results/judge_prompt.txt
+++ b/homeworks/hw3/results/judge_prompt.txt
@@ -21,6 +21,27 @@ DIETARY RESTRICTION DEFINITIONS:
 EVALUATION CRITERIA:
 - PASS: The recipe clearly adheres to the dietary preferences with appropriate ingredients and preparation methods
 - FAIL: The recipe contains ingredients or methods that violate the dietary preferences
+DIETARY RESTRICTION DEFINITIONS:
+- Vegan: No animal products (meat, dairy, eggs, honey, etc.)
+- Vegetarian: No meat or fish, but dairy and eggs are allowed
+- Gluten-free: No wheat, barley, rye, or other gluten-containing grains
+- Dairy-free: No milk, cheese, butter, yogurt, or other dairy products
+- Keto: Very low carb (typically <20g net carbs), high fat, moderate protein
+- Paleo: No grains, legumes, dairy, refined sugar, or processed foods
+- Pescatarian: No meat except fish and seafood
+- Kosher: Follows Jewish dietary laws (no pork, shellfish, mixing meat/dairy)
+- Halal: Follows Islamic dietary laws (no pork, alcohol, proper slaughter)
+- Nut-free: No tree nuts or peanuts
+- Low-carb: Significantly reduced carbohydrates (typically <50g per day)
+- Sugar-free: No added sugars or high-sugar ingredients
+- Raw vegan: Vegan foods not heated above 118°F (48°C)
+- Whole30: No grains, dairy, legumes, sugar, alcohol, or processed foods
+- Diabetic-friendly: Low glycemic index, controlled carbohydrates
+- Low-sodium: Reduced sodium content for heart health
+
+EVALUATION CRITERIA:
+- PASS: The recipe clearly adheres to the dietary preferences with appropriate ingredients and preparation methods
+- FAIL: The recipe contains ingredients or methods that violate the dietary preferences
 - Consider both explicit ingredients and cooking methods
 
 Here are some examples of how to evaluate dietary adherence:
@@ -122,6 +143,8 @@ Recipe Response: I recommend making **Lemon Herb Grilled Chicken with Roasted Ve
 This meal is light, packed with fresh flavors, and satisfying without heaviness. Enjoy!
 Reasoning: The recipe response includes 'Lemon Herb Grilled Chicken with Roasted Vegetables,' which contains chicken breasts as a primary ingredient. The dietary restriction specified is vegetarian, which excludes all forms of meat, including chicken. Therefore, the inclusion of chicken in the recipe directly violates the vegetarian dietary restriction.
 Label: FAIL
+Reasoning: The recipe response includes 'Lemon Herb Grilled Chicken with Roasted Vegetables,' which contains chicken breasts as a primary ingredient. The dietary restriction specified is vegetarian, which excludes all forms of meat, including chicken. Therefore, the inclusion of chicken in the recipe directly violates the vegetarian dietary restriction.
+Label: FAIL
 
 Example 3:
 Query: Gluten-light recipe - I'm not celiac just sensitive
@@ -211,6 +234,9 @@ Label: FAIL
 
 Now evaluate the following recipe response:
 
+Query: __QUERY__
+Dietary Restriction: __DIETARY_RESTRICTION__
+Recipe Response: __RESPONSE__
 Query: __QUERY__
 Dietary Restriction: __DIETARY_RESTRICTION__
 Recipe Response: __RESPONSE__

--- a/homeworks/hw3/scripts/develop_judge.py
+++ b/homeworks/hw3/scripts/develop_judge.py
@@ -57,7 +57,7 @@ MAX_WORKERS = 32
 console = Console()
 
 # Model used for the LLM judge
-MODEL_NAME_JUDGE: Final[str] = os.environ.get("MODEL_NAME_JUDGE", "gpt-4o-nano")
+MODEL_NAME_JUDGE: Final[str] = os.environ.get("MODEL_NAME_JUDGE", "gpt-4.1-nano")
 
 def load_data_split(csv_path: str) -> List[Dict[str, Any]]:
     """Load a data split from CSV file."""

--- a/homeworks/hw3/scripts/develop_judge.py
+++ b/homeworks/hw3/scripts/develop_judge.py
@@ -28,6 +28,8 @@ When using a prompt of your own design, be sure to:
   The script uses these to embed the query, dietary restriction and recipe response in the
   evaluation prompt.
 """
+
+import os
 import json
 import pandas as pd
 import random

--- a/homeworks/hw3/scripts/evaluate_judge.py
+++ b/homeworks/hw3/scripts/evaluate_judge.py
@@ -5,10 +5,11 @@ This script evaluates the finalized LLM judge on the test set to get
 unbiased estimates of TPR and TNR for use with judgy.
 """
 
+import os
 import pandas as pd
 import json
 from pathlib import Path
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Final
 from rich.console import Console
 from rich.progress import track
 import litellm
@@ -20,6 +21,9 @@ load_dotenv()
 MAX_WORKERS = 32
 
 console = Console()
+
+# Model used for the LLM judge
+MODEL_NAME_JUDGE: Final[str] = os.environ.get("MODEL_NAME_JUDGE", "gpt-4o-nano")
 
 def load_data_split(csv_path: str) -> List[Dict[str, Any]]:
     """Load a data split from CSV file."""
@@ -48,7 +52,7 @@ def evaluate_single_trace(args: tuple) -> Dict[str, Any]:
     try:
         # Get judge prediction
         completion = litellm.completion(
-            model="gpt-4.1-nano",  # Use the same model as in development
+            model=MODEL_NAME_JUDGE,  # Use the same model as in development
             messages=[{"role": "user", "content": formatted_prompt}],
         )
         

--- a/homeworks/hw3/scripts/label_data.py
+++ b/homeworks/hw3/scripts/label_data.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 """Label Recipe Bot traces for dietary adherence using GPT-4o.
 
-This script uses GPT-4o as a powerful labeler to create ground truth labels
-for whether Recipe Bot responses properly adhere to dietary restrictions.
+This script can be used as a powerful automatic labeler to create ground
+truth labels for whether Recipe Bot responses properly adhere to dietary restrictions.
+It uses GPT-4o as a powerful labeler and also comes with a well designed and tested 
+labeling prompt.
+
+Remember that automatic creation of ground truth labels should never be used without
+also looking extensively at the data. This script is intended as a fast way to give
+you "ground truth" for this homework assignment.
 """
 
 import pandas as pd

--- a/homeworks/hw3/scripts/run_full_evaluation.py
+++ b/homeworks/hw3/scripts/run_full_evaluation.py
@@ -5,11 +5,12 @@ This script runs the finalized judge on all traces and uses judgy to compute
 the corrected success rate with confidence intervals.
 """
 
+import os
 import pandas as pd
 import json
 import numpy as np
 from pathlib import Path
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Final
 from rich.console import Console
 from rich.progress import track
 import litellm
@@ -19,6 +20,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 console = Console()
+
+# Model used for the LLM judge
+MODEL_NAME_JUDGE: Final[str] = os.environ.get("MODEL_NAME_JUDGE", "gpt-4o-nano")
 
 MAX_WORKERS = 32
 
@@ -54,7 +58,7 @@ def evaluate_single_trace_for_binary(args: tuple) -> int:
     try:
         # Get judge prediction
         completion = litellm.completion(
-            model="gpt-4.1-nano",
+            model=MODEL_NAME_JUDGE,
             messages=[{"role": "user", "content": formatted_prompt}],
         )
         


### PR DESCRIPTION
This pull request (unfortunately) addresses multiple changes in one go:

1. Add the option to set the LLM judge model in the `.env` file, just like the chat model
2. Added the option to use a manual LLM_judge prompt from `judge_prompt.txt` instead of generating it from within the `develop_judge.py` script. Rationale behind this added feature can be found in `develop_judge.py`.
3. Some minor changes in the hw3_walkthrough and hw3 README.md which make things hopefully more clear.

Accidentally also pushed the changes that happened to the files: `judge_prompt.txt` and `dev_predictions.json`.
Please reject and ignore those.