### PR TITLE
Port attempt1 work onto current course structure

### DIFF
--- a/data/sample_queries.csv
+++ b/data/sample_queries.csv
@@ -2,3 +2,15 @@ id,query
 1,Suggest a quick vegan breakfast recipe
 2,I have chicken and rice. what can I cook?
 3,Give me a dessert recipe with chocolate 
+4,Give me a recipe for air fryer salmon and asparagus
+5,Scale this recipe up for 1.92 pounds
+6,what can i add to a red wine glaze to make it sweeter? (not just sugar)
+7,"I'm cooking sous vide short ribs as the main dish for date night tonight with my girlfriend. What would be some good side dishes for it? Want something healthy, nourishing and restorative. It's also hot right now so not something super heavy"
+8,give me a gluten and diary free recipe for thanksgiving stuffing
+9,suggest some low carb + GF sides for thanksgiving
+10,Help me brainstorm a dish to take to this potluck. Something simple to make (30-45 min max) that's dairy and gluten free
+11,give me a GF and keto / low carb dessert recipe for lemon meringue pie
+12,"Help me brainstorm some easy to make dishes for a group dinner of 10 people. Gluten free, dairy free (or light). If there is a way to make a dish that a vegetarian person can easily have (where the meat can be on side and mixed in by those who eat meat) that is ideal. Bias to grilling meats and large batch cooking that I can complete in 1 hour or less."
+13,I want a main and two sides
+14,Let's do grilled chicken as the main dish. Then create 2 side options and a salad
+15,help me make a quick dinner with protein and veggies

--- a/homeworks/hw1/my_work/README.md
+++ b/homeworks/hw1/my_work/README.md
@@ -1,0 +1,23 @@
+# HW1 — My Work
+
+Ported from my original `attempt1` branch (pre-course-redesign fork).
+
+## What's here
+
+- **`system_prompt.md`** — My structured system prompt from HW1 Part 1. Originally written as an inline `SYSTEM_PROMPT` string constant in `backend/utils.py` (the old HW1 instructions). The course later moved the prompt into `backend/system_prompt.md` loaded via `read_text()`.
+
+## How to use it for HW1
+
+The current HW1 readme (Part 1) says: *"Replace `backend/system_prompt.md` with a well-crafted system prompt."* This file IS that deliverable. When working HW1:
+
+```bash
+cp homeworks/hw1/my_work/system_prompt.md backend/system_prompt.md
+```
+
+Then run the bulk test per Part 3.
+
+> `backend/system_prompt.md` is intentionally left as the course's placeholder on this branch so the diff stays clean. Swap it in when you actually do HW1.
+
+## HW1 Part 2 (sample queries)
+
+Already done: my 12 additional diverse queries (ids 4–15) are merged into `data/sample_queries.csv` on this branch, appended after the course's 3 starter rows.

--- a/homeworks/hw1/my_work/system_prompt.md
+++ b/homeworks/hw1/my_work/system_prompt.md
@@ -1,0 +1,109 @@
+You are a friendly culinary assistant specializing in easy-to-follow recipes for beginner-to-intermediate home cooks.
+
+# CORE BEHAVIOR
+
+When a user asks for a recipe:
+1. Provide complete recipes with precise measurements using standard units (cups, tbsp, tsp, oz, etc.)
+2. Include clear, numbered step-by-step instructions
+3. Always include a shopping list grouped by grocery store section
+4. Default to recipes that take ≤60 minutes total (prep + cook time) unless user specifies otherwise
+5. Ask about dietary restrictions or allergies only if the user's request might be affected by them
+
+# CONSTRAINTS
+
+ALWAYS DO:
+- Use common, grocery-store-available ingredients
+- Offer easy-to-find substitutions when suggesting specialty ingredients
+- Format responses in clean, consistent Markdown
+- Be encouraging and supportive for beginners
+
+NEVER DO:
+- Suggest recipes with rare/unobtainable ingredients without accessible alternatives
+- Provide recipes for unsafe, unethical, or harmful purposes (decline politely without being preachy)
+- Use offensive or derogatory language
+- Overcomplicate recipes unnecessarily
+
+# CREATIVE FREEDOM
+
+You may:
+- Suggest common ingredient variations and substitutions
+- Combine elements from known recipes to create novel dishes that match user preferences
+- Clearly label any recipes that are creative adaptations vs. traditional recipes
+
+# OUTPUT FORMAT
+
+Every recipe response MUST follow this structure:
+
+## [Recipe Name]
+[1-3 sentence enticing description]
+
+### Ingredients
+- [ingredient with measurement]
+- [ingredient with measurement]
+
+### Instructions
+1. [First step]
+2. [Second step]
+3. [Continue...]
+
+### Tips
+[Optional: helpful cooking tips or techniques]
+
+### Variations
+[Optional: substitutions or modifications]
+
+### Shopping List
+**Produce**
+- [ ] [item]
+
+**Meat/Seafood**
+- [ ] [item]
+
+**Dairy**
+- [ ] [item]
+
+**Pantry/Dry Goods**
+- [ ] [item]
+
+**Other**
+- [ ] [item]
+
+---
+
+EXAMPLE RESPONSE:
+
+## Golden Pan-Fried Salmon
+
+A quick and delicious way to prepare salmon with a crispy skin and moist interior, perfect for a weeknight dinner.
+
+### Ingredients
+- 2 salmon fillets (approx. 6oz each, skin-on)
+- 1 tbsp olive oil
+- Salt, to taste
+- Black pepper, to taste
+- 1 lemon, cut into wedges (for serving)
+
+### Instructions
+1. Pat the salmon fillets completely dry with a paper towel, especially the skin.
+2. Season both sides of the salmon with salt and pepper.
+3. Heat olive oil in a non-stick skillet over medium-high heat until shimmering.
+4. Place salmon fillets skin-side down in the hot pan.
+5. Cook for 4-6 minutes on the skin side, pressing down gently with a spatula for the first minute to ensure crispy skin.
+6. Flip the salmon and cook for another 2-4 minutes on the flesh side, or until cooked through to your liking.
+7. Serve immediately with lemon wedges.
+
+### Tips
+- For extra flavor, add a smashed garlic clove and a sprig of rosemary to the pan while cooking
+- Ensure the pan is hot before adding the salmon for the best sear
+
+### Shopping List
+**Meat/Seafood**
+- [ ] 2 salmon fillets (6oz each, skin-on)
+
+**Produce**
+- [ ] 1 lemon
+
+**Pantry/Dry Goods**
+- [ ] Olive oil
+- [ ] Salt
+- [ ] Black pepper

--- a/homeworks/hw2/my_work/NOTES.md
+++ b/homeworks/hw2/my_work/NOTES.md
@@ -1,0 +1,105 @@
+# HW2 — My Work (ported from attempt1)
+
+These are my in-progress HW2 notes from before resuming the course. The course
+**rewrote the HW2 assignment** since I forked, so the official flow now lives in
+`../README.md` and ships `../reference_files/` (250-pair `query_response.jsonl`,
+`viewer.html`, `failure_mode_taxonomy.md` template). My original work is preserved
+here so nothing is lost.
+
+> Status when I paused: finished Part 1 (dimensions → tuples → synthetic queries).
+> Part 2 (run bot, open coding, axial coding, taxonomy) **not started** —
+> `error_analysis.csv` is just a header row.
+
+---
+
+## Part 1 — Synthetic Query Generation (DONE)
+
+### Step 1: Key Dimensions
+
+- `dietary_restriction`: gluten free, dairy free, keto, low carb, vegetarian, vegan, pescatarian
+- `dish_type`: appetizer, main, dessert, side, salad
+- `time_available`: 15 min, 30 min, 45 min, 1 hour, 2 hour, >2 hours
+- `number_of_people`: 1, 2, 3, 4, 6, 8
+- `number_of_dishes`: 1, 2, 3, 4, 5
+- `meal`: breakfast, lunch, dinner, snack
+- `equipment_available`: microwave only, stove only, stove and oven, no microwave, sous vide, air fryer
+
+### Step 2: Unique Tuple Combos
+
+Two routes I used:
+
+1. **LLM prompt** (the prompt I wrote is below) → ~50 hand-collected 3-tuples.
+2. **Script**: `generate_query_combinations.py` (seeded `random.seed(42)` for
+   reproducibility) → `query_combinations.csv` (50 rows, with dimension names).
+
+LLM prompt I used:
+
+> Taking the below dimensions + example values, generate ~50 unique 3-tuple combinations of the values.
+>
+> Output 3-tuples where each tuple is only values (don't include dimension names in the tuple). Here are the dimensions and values:
+>
+> - `dietary_restriction`: gluten free, dairy free, keto, low carb, vegetarian, vegan, pescatarian
+> - `dish_type`: appetizer, main, dessert, side, salad
+> - `time_available`: 15 min, 30 min, 45 min, 1 hour, 2 hour, >2 hours
+> - `number_of_people`: 1, 2, 3, 4, 6, 8
+> - `number_of_dishes`: 1, 2, 3, 4, 5
+> - `meal`: breakfast, lunch, dinner, snack
+> - `equipment_available`: microwave only, stove only, stove and oven, no microwave, sous vide, air fryer
+>
+> Select a unique combination of 3 dimensions from the list of 8 dimensions (e.g. dish_type, meal, number_of_people), then select a value from each of those dimensions to make a unique 3-tuple, with each position in the tuple representing a value selected from the set for each dimension selected.
+>
+> Each 3-tuple of values should be unique within the overall list of tuples.
+
+### Step 3: Natural-Language User Queries
+
+LLM prompt: *generate realistic user queries a user might input to a recipe
+chatbot. Select 5–7 tuples from the sample data, generate one natural-language
+query per tuple.* Final 7 queries are in `synthetic_queries.csv`:
+
+1. I need a quick vegan dessert I can make in 30 minutes or less — `(vegan, dessert, 30 min)`
+2. What's a good low carb recipe I can make in my air fryer? Need something quick, maybe 30 min — `(low carb, air fryer, 30 min)`
+3. Give me a pescatarian main dish recipe that I can make in about an hour — `(pescatarian, main, 1 hour)`
+4. I'm hosting a lunch for 8 people and need some good appetizer ideas — `(lunch, appetizer, 8)`
+5. Looking for a keto-friendly salad recipe. I have access to stove and oven if I need to roast anything — `(keto, salad, stove and oven)`
+6. Need to make dairy free lunch for 8 people. What would you suggest? — `(dairy free, lunch, 8)`
+7. Help me with a main dish for 3 people that I can get done in 45 minutes max — `(main, 3, 45 min)`
+
+---
+
+## Part 2 — Error Analysis (NOT STARTED)
+
+Open questions / TODOs I had logged before the course redesign (several are now
+**resolved by the redesign** — annotated inline):
+
+- ~~"Am I missing some automated tool for getting traces, or do I run them manually?"~~
+  → **Resolved**: the new HW2 ships `reference_files/query_response.jsonl` (250
+  pairs) + `viewer.html`. No need to capture traces myself.
+- ~~"How do I record full traces? They save automatically to `annotation/traces`
+  on manual chat but not from the bulk script. TODO: update bulk script to
+  record traces."~~ → **Resolved/obsolete**: course rewrote `scripts/bulk_test.py`
+  to write JSON to `results/`, and HW2 no longer depends on me capturing traces.
+  My old `save_trace` refactor is archived in `/old_artifacts/` if ever needed.
+- "How many traces to code — just 5–7, or 100+?" → still a real question;
+  the new README/reference data (250 pairs) implies code a meaningful sample,
+  not just 7.
+
+### Next steps (on the NEW structure)
+
+1. Read `../README.md` (rewritten flow) and skim `../reference_files/viewer.html`
+   over `query_response.jsonl`.
+2. Decide: use my 7 synthetic queries, or the course's 250-pair dataset (likely
+   the latter for open coding volume).
+3. Open coding → axial coding → fill `../reference_files/failure_mode_taxonomy.md`.
+4. Track in a spreadsheet (my empty-header `error_analysis.csv` can be the start,
+   but the new README's column scheme supersedes it).
+
+---
+
+## File inventory
+
+| File | What it is |
+|---|---|
+| `synthetic_queries.csv` | My 7 final Part-1 natural-language queries |
+| `query_combinations.csv` | 50 tuples from the generator script |
+| `generate_query_combinations.py` | Seeded tuple generator (output path patched to relative) |
+| `error_analysis.csv` | Empty analysis sheet (header only — Part 2 not started) |

--- a/homeworks/hw2/my_work/error_analysis.csv
+++ b/homeworks/hw2/my_work/error_analysis.csv
@@ -1,0 +1,1 @@
+﻿Trace_ID,User_Query,Full_Bot_Trace_Summary,Open_Code_Notes

--- a/homeworks/hw2/my_work/generate_query_combinations.py
+++ b/homeworks/hw2/my_work/generate_query_combinations.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Generate diverse 3-tuple combinations for recipe queries."""
+
+import random
+import csv
+from itertools import combinations, product
+
+# Define dimensions
+dimensions = {
+    'dietary_restriction': ['gluten free', 'dairy free', 'keto', 'low carb', 'vegetarian', 'vegan', 'pescatarian'],
+    'dish_type': ['appetizer', 'main', 'dessert', 'side', 'salad'],
+    'time_available': ['15 min', '30 min', '45 min', '1 hour', '2 hour', '>2 hours'],
+    'number_of_people': ['1', '2', '3', '4', '6', '8'],
+    'number_of_dishes': ['1', '2', '3', '4', '5'],
+    'meal': ['breakfast', 'lunch', 'dinner', 'snack'],
+    'equipment_available': ['microwave only', 'stove only', 'stove and oven', 'no microwave', 'sous vide', 'air fryer']
+}
+
+# Define common dimension groupings that make sense together
+dimension_groups = [
+    ['dietary_restriction', 'dish_type', 'time_available'],
+    ['dietary_restriction', 'meal', 'number_of_people'],
+    ['dish_type', 'time_available', 'equipment_available'],
+    ['meal', 'number_of_people', 'dietary_restriction'],
+    ['dish_type', 'number_of_people', 'time_available'],
+    ['dietary_restriction', 'equipment_available', 'time_available'],
+    ['meal', 'dish_type', 'number_of_people'],
+    ['number_of_dishes', 'meal', 'number_of_people'],
+    ['dietary_restriction', 'dish_type', 'equipment_available'],
+    ['meal', 'time_available', 'equipment_available'],
+    ['dish_type', 'meal', 'time_available'],
+    ['number_of_dishes', 'dietary_restriction', 'meal'],
+    ['equipment_available', 'number_of_people', 'meal'],
+]
+
+def generate_combinations(target_count=50):
+    """Generate diverse 3-tuple combinations (values only)."""
+    value_tuples = []
+    seen = set()
+
+    # Generate combinations from each dimension group
+    for group in dimension_groups:
+        # Get all possible value combinations for this dimension group
+        values = [dimensions[dim] for dim in group]
+        all_combos = list(product(*values))
+
+        # Sample some combinations from this group
+        sample_size = min(target_count // len(dimension_groups) + 2, len(all_combos))
+        sampled = random.sample(all_combos, sample_size)
+
+        for value_tuple in sampled:
+            if value_tuple not in seen:
+                seen.add(value_tuple)
+                value_tuples.append({
+                    'dimensions': group,
+                    'values': value_tuple
+                })
+
+    # Shuffle and trim to target count
+    random.shuffle(value_tuples)
+    return value_tuples[:target_count]
+
+def format_output(combinations):
+    """Format combinations as readable output."""
+    output = []
+    for i, combo in enumerate(combinations, 1):
+        # Format as just the value tuple
+        value_str = str(combo['values'])
+        output.append(f"{i}. {value_str}")
+    return '\n'.join(output)
+
+if __name__ == "__main__":
+    random.seed(42)  # For reproducibility
+    combos = generate_combinations(50)
+    print(format_output(combos))
+
+    # Also save as CSV
+    output_file = "query_combinations.csv"
+    with open(output_file, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow(['combination_id', 'value1', 'value2', 'value3', 'dim1_name', 'dim2_name', 'dim3_name'])
+
+        for i, combo in enumerate(combos, 1):
+            row = [i]
+            row.extend(combo['values'])  # Add the three values
+            row.extend(combo['dimensions'])  # Add dimension names for reference
+            writer.writerow(row)
+
+    print(f"\n✓ Saved to {output_file}")

--- a/homeworks/hw2/my_work/query_combinations.csv
+++ b/homeworks/hw2/my_work/query_combinations.csv
@@ -1,0 +1,51 @@
+combination_id,value1,value2,value3,dim1_name,dim2_name,dim3_name
+1,vegan,snack,2,dietary_restriction,meal,number_of_people
+2,vegan,dessert,30 min,dietary_restriction,dish_type,time_available
+3,low carb,air fryer,30 min,dietary_restriction,equipment_available,time_available
+4,breakfast,appetizer,1,meal,dish_type,number_of_people
+5,breakfast,1 hour,air fryer,meal,time_available,equipment_available
+6,lunch,2,pescatarian,meal,number_of_people,dietary_restriction
+7,2,gluten free,snack,number_of_dishes,dietary_restriction,meal
+8,breakfast,2 hour,stove and oven,meal,time_available,equipment_available
+9,pescatarian,main,1 hour,dietary_restriction,dish_type,time_available
+10,salad,30 min,stove only,dish_type,time_available,equipment_available
+11,keto,salad,stove and oven,dietary_restriction,dish_type,equipment_available
+12,side,8,>2 hours,dish_type,number_of_people,time_available
+13,lunch,appetizer,8,meal,dish_type,number_of_people
+14,snack,6,gluten free,meal,number_of_people,dietary_restriction
+15,snack,side,4,meal,dish_type,number_of_people
+16,dinner,2 hour,stove only,meal,time_available,equipment_available
+17,4,dinner,8,number_of_dishes,meal,number_of_people
+18,snack,dessert,2,meal,dish_type,number_of_people
+19,low carb,stove only,15 min,dietary_restriction,equipment_available,time_available
+20,4,low carb,breakfast,number_of_dishes,dietary_restriction,meal
+21,5,pescatarian,lunch,number_of_dishes,dietary_restriction,meal
+22,gluten free,main,15 min,dietary_restriction,dish_type,time_available
+23,stove and oven,1,lunch,equipment_available,number_of_people,meal
+24,side,15 min,microwave only,dish_type,time_available,equipment_available
+25,1,snack,3,number_of_dishes,meal,number_of_people
+26,dairy free,no microwave,45 min,dietary_restriction,equipment_available,time_available
+27,dairy free,lunch,8,dietary_restriction,meal,number_of_people
+28,gluten free,salad,2 hour,dietary_restriction,dish_type,time_available
+29,5,lunch,2,number_of_dishes,meal,number_of_people
+30,salad,dinner,15 min,dish_type,meal,time_available
+31,keto,air fryer,>2 hours,dietary_restriction,equipment_available,time_available
+32,appetizer,2,15 min,dish_type,number_of_people,time_available
+33,5,dairy free,lunch,number_of_dishes,dietary_restriction,meal
+34,pescatarian,dessert,no microwave,dietary_restriction,dish_type,equipment_available
+35,main,lunch,1 hour,dish_type,meal,time_available
+36,main,snack,45 min,dish_type,meal,time_available
+37,2,snack,2,number_of_dishes,meal,number_of_people
+38,breakfast,4,keto,meal,number_of_people,dietary_restriction
+39,snack,main,2,meal,dish_type,number_of_people
+40,breakfast,2 hour,microwave only,meal,time_available,equipment_available
+41,3,lunch,1,number_of_dishes,meal,number_of_people
+42,keto,main,2 hour,dietary_restriction,dish_type,time_available
+43,dairy free,main,no microwave,dietary_restriction,dish_type,equipment_available
+44,side,breakfast,>2 hours,dish_type,meal,time_available
+45,no microwave,1,snack,equipment_available,number_of_people,meal
+46,appetizer,30 min,stove and oven,dish_type,time_available,equipment_available
+47,main,3,45 min,dish_type,number_of_people,time_available
+48,microwave only,8,breakfast,equipment_available,number_of_people,meal
+49,appetizer,1 hour,sous vide,dish_type,time_available,equipment_available
+50,salad,4,2 hour,dish_type,number_of_people,time_available

--- a/homeworks/hw2/my_work/synthetic_queries.csv
+++ b/homeworks/hw2/my_work/synthetic_queries.csv
@@ -1,0 +1,8 @@
+id,query
+1,I need a quick vegan dessert I can make in 30 minutes or less
+2,"What's a good low carb recipe I can make in my air fryer? Need something quick, maybe 30 min"
+3,Give me a pescatarian main dish recipe that I can make in about an hour
+4,I'm hosting a lunch for 8 people and need some good appetizer ideas
+5,"Looking for a keto-friendly salad recipe. I have access to stove and oven if I need to roast anything"
+6,Need to make dairy free lunch for 8 people. What would you suggest?
+7,Help me with a main dish for 3 people that I can get done in 45 minutes max

--- a/old_artifacts/attempt1-save_trace-refactor/README.md
+++ b/old_artifacts/attempt1-save_trace-refactor/README.md
@@ -1,0 +1,47 @@
+# Archived: `save_trace` refactor from `attempt1`
+
+These are **frozen copies** of my original files from the pre-redesign `attempt1`
+branch. They are NOT wired into the live backend. The live `backend/` and
+`scripts/` on this branch use the **course's current code** unchanged.
+
+## Why this is archived (not merged)
+
+My `attempt1` work added a `save_trace()` helper to `backend/utils.py` and called
+it from both `backend/main.py` (chat endpoint) and `scripts/bulk_test.py`, so the
+bulk script would persist conversation traces to `annotation/traces/*.json` the
+same way the manual chat path did.
+
+The course later **independently solved the same problem differently**:
+
+- `scripts/bulk_test.py` was rewritten (`read_queries` / `process_query` /
+  `write_results`) to emit JSON to `results/results_<ts>.json`.
+- HW2 now ships `homeworks/hw2/reference_files/query_response.jsonl` (250
+  pre-generated query/response pairs) + a `viewer.html`, so capturing traces
+  from the bulk script is no longer required to do the homework.
+
+So porting `save_trace` forward would reintroduce a mechanism the new workflow
+doesn't need, and conflict with the rewritten `bulk_test.py`. Archived instead of
+discarded so it's recoverable.
+
+## Files
+
+| File | Original location | Notes |
+|---|---|---|
+| `utils.py` | `backend/utils.py` | Inline `SYSTEM_PROMPT` constant + `save_trace()`. (Prompt itself is preserved separately at `homeworks/hw1/my_work/system_prompt.md`.) |
+| `main.py` | `backend/main.py` | Chat endpoint calling `save_trace(...)` instead of inline json.dump |
+| `bulk_test.py` | `scripts/bulk_test.py` | Old sync `process_query_sync` calling `save_trace` |
+| `save_trace_snippet.py` | — | Just the `save_trace()` function, extracted for easy reuse |
+
+## If I ever want trace-capture in the new bulk script
+
+The new `scripts/bulk_test.py` already writes structured JSON results. If I want
+per-trace files too, the minimal path is:
+
+1. Copy `save_trace()` from `save_trace_snippet.py` into the current
+   `backend/utils.py`.
+2. In the current `scripts/bulk_test.py` `process_query()`, call
+   `save_trace([{ "role": "user", "content": query }], updated_history)` before
+   returning.
+
+Don't bulk-copy these archived files over the current ones — the surrounding code
+has diverged significantly.

--- a/old_artifacts/attempt1-save_trace-refactor/bulk_test.py
+++ b/old_artifacts/attempt1-save_trace-refactor/bulk_test.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add project root to sys.path to allow a_s_b_absolute imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+"""Bulk testing utility for the recipe chatbot agent.
+
+Reads a CSV file containing user queries, fires them against the `/chat`
+endpoint concurrently, and stores the results for later manual evaluation.
+"""
+
+import argparse
+import csv
+import datetime as dt
+from typing import List, Tuple, Dict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.text import Text
+from rich.markdown import Markdown
+
+from backend.utils import get_agent_response, SYSTEM_PROMPT, save_trace
+
+# -----------------------------------------------------------------------------
+# Configuration helpers
+# -----------------------------------------------------------------------------
+
+DEFAULT_CSV: Path = Path("data/sample_queries.csv")
+RESULTS_DIR: Path = Path("results")
+RESULTS_DIR.mkdir(exist_ok=True)
+
+MAX_WORKERS = 32 # For ThreadPoolExecutor
+
+# -----------------------------------------------------------------------------
+# Core logic
+# -----------------------------------------------------------------------------
+
+# --- Sync function for ThreadPoolExecutor ---
+def process_query_sync(query_id: str, query: str) -> Tuple[str, str, str]:
+    """Processes a single query by calling the agent directly."""
+    initial_messages: List[Dict[str, str]] = [
+        {"role": "user", "content": query}
+    ]
+    try:
+        # get_agent_response now returns the full history
+        updated_history = get_agent_response(initial_messages)
+
+        # Save trace
+        save_trace(initial_messages, updated_history)
+
+        # Extract the last assistant message for the result
+        assistant_reply = ""
+        if updated_history and updated_history[-1]["role"] == "assistant":
+            assistant_reply = updated_history[-1]["content"]
+        else: # Should not happen with current logic but good to handle
+            assistant_reply = "Error: No assistant reply found in history."
+        return query_id, query, assistant_reply
+    except Exception as e:
+        return query_id, query, f"Error processing query: {str(e)}"
+
+
+# Renamed and made sync
+def run_bulk_test(csv_path: Path, num_workers: int = MAX_WORKERS) -> None:
+    """Main entry point for bulk testing (synchronous version)."""
+
+    with csv_path.open("r", newline="", encoding="utf-8") as csv_file:
+        reader = csv.DictReader(csv_file)
+        # Expects columns 'id' and 'query'
+        input_data: List[Dict[str, str]] = [
+            row for row in reader if row.get("id") and row.get("query")
+        ]
+
+    if not input_data:
+        raise ValueError("No valid data (with 'id' and 'query') found in the provided CSV file.")
+
+    console = Console()
+    results_data: List[Tuple[str, str, str]] = [] # Will store (id, query, response)
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        future_to_data = {
+            executor.submit(process_query_sync, item["id"], item["query"]):
+            item for item in input_data
+        }
+        console.print(f"[bold blue]Submitting {len(input_data)} queries to the executor...[/bold blue]")
+        for i, future in enumerate(as_completed(future_to_data)):
+            item_data = future_to_data[future]
+            item_id = item_data["id"]
+            item_query = item_data["query"]
+            try:
+                processed_id, original_query, response_text = future.result()
+                results_data.append((processed_id, original_query, response_text))
+
+                panel_content = Text()
+                panel_content.append(f"ID: {processed_id}\n", style="bold magenta")
+                panel_content.append("Query:\n", style="bold yellow")
+                panel_content.append(f"{original_query}\n\n")
+
+                # Create a separate Markdown object for the response
+                response_markdown = Markdown(response_text)
+
+                # Group the different parts for the Panel
+                panel_group = Group(
+                    panel_content, # Contains ID and Query
+                    Markdown("--- Response ---"), # A small separator for clarity
+                    response_markdown  # The Markdown rendered response
+                )
+
+                console.print(Panel(
+                    panel_group, # Pass the group as the single renderable
+                    title=f"Result {i+1}/{len(input_data)} - ID: {processed_id}", 
+                    border_style="cyan"
+                ))
+
+            except Exception as exc:
+                console.print(Panel(f"[bold red]Exception for ID {item_id}, Query:[/bold red]\n{item_query}\n\n[bold red]Error:[/bold red]\n{exc}", title=f"Error in Result {i+1}/{len(input_data)} - ID: {item_id}", border_style="red"))
+                results_data.append((item_id, item_query, f"Exception during processing: {str(exc)}"))
+        console.print("[bold blue]All queries processed.[/bold blue]")
+
+    timestamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = RESULTS_DIR / f"results_{timestamp}.csv"
+
+    with out_path.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["id", "query", "response"])
+        writer.writerows(results_data)
+
+    console.print(f"[bold green]Saved {len(results_data)} results to {str(out_path)}[/bold green]")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Bulk test the recipe chatbot")
+    parser.add_argument("--csv", type=Path, default=DEFAULT_CSV, help="Path to CSV file containing queries (column name: 'query').")
+    parser.add_argument("--workers", type=int, default=MAX_WORKERS, help=f"Number of worker threads (default: {MAX_WORKERS}).")
+    args = parser.parse_args()
+    run_bulk_test(args.csv, args.workers)

--- a/old_artifacts/attempt1-save_trace-refactor/main.py
+++ b/old_artifacts/attempt1-save_trace-refactor/main.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""FastAPI application entry-point for the recipe chatbot."""
+
+from pathlib import Path
+from typing import Final, List, Dict
+
+from fastapi import FastAPI, HTTPException, status
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+
+from backend.utils import get_agent_response, save_trace  # noqa: WPS433 import from parent
+
+# -----------------------------------------------------------------------------
+# Application setup
+# -----------------------------------------------------------------------------
+
+APP_TITLE: Final[str] = "Recipe Chatbot"
+app = FastAPI(title=APP_TITLE)
+
+# Serve static assets (currently just the HTML) under `/static/*`.
+STATIC_DIR = Path(__file__).parent.parent / "frontend"
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+# -----------------------------------------------------------------------------
+# Request / response models
+# -----------------------------------------------------------------------------
+
+class ChatMessage(BaseModel):
+    """Schema for a single message in the chat history."""
+    role: str = Field(..., description="Role of the message sender (system, user, or assistant).")
+    content: str = Field(..., description="Content of the message.")
+
+class ChatRequest(BaseModel):
+    """Schema for incoming chat messages."""
+
+    messages: List[ChatMessage] = Field(..., description="The entire conversation history.")
+
+
+class ChatResponse(BaseModel):
+    """Schema for the assistant's reply returned to the front-end."""
+
+    messages: List[ChatMessage] = Field(..., description="The updated conversation history.")
+
+
+# -----------------------------------------------------------------------------
+# Routes
+# -----------------------------------------------------------------------------
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat_endpoint(payload: ChatRequest) -> ChatResponse:  # noqa: WPS430
+    """Main conversational endpoint.
+
+    It proxies the user's message list to the underlying agent and returns the updated list.
+    """
+    # Convert Pydantic models to simple dicts for the agent
+    request_messages: List[Dict[str, str]] = [msg.model_dump() for msg in payload.messages]
+
+    try:
+        updated_messages_dicts = get_agent_response(request_messages)
+    except Exception as exc:  # noqa: BLE001 broad; surface as HTTP 500
+        # In production you would log the traceback here.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        ) from exc
+
+    response = ChatResponse(messages=[ChatMessage(**msg) for msg in updated_messages_dicts])
+
+    # Save trace (request and response)
+    save_trace(request_messages, updated_messages_dicts)
+
+    return response
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:  # noqa: WPS430
+    """Serve the chat UI."""
+
+    html_path = STATIC_DIR / "index.html"
+    if not html_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Frontend not found. Did you forget to build it?",
+        )
+
+    return HTMLResponse(html_path.read_text(encoding="utf-8")) 

--- a/old_artifacts/attempt1-save_trace-refactor/save_trace_snippet.py
+++ b/old_artifacts/attempt1-save_trace-refactor/save_trace_snippet.py
@@ -1,0 +1,34 @@
+import json
+import datetime
+from pathlib import Path
+from typing import List, Dict
+
+
+def save_trace(request_messages: List[Dict[str, str]], response_messages: List[Dict[str, str]]) -> Path:
+    """Save conversation trace to annotation/traces directory.
+
+    Parameters
+    ----------
+    request_messages:
+        The request messages (conversation history before the agent response).
+    response_messages:
+        The response messages (full conversation history including the agent response).
+
+    Returns
+    -------
+    Path
+        Path to the saved trace file.
+    """
+    traces_dir = Path(__file__).parent.parent / "annotation" / "traces"
+    traces_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    trace_path = traces_dir / f"trace_{ts}.json"
+
+    with open(trace_path, "w", encoding="utf-8") as f:
+        json.dump({
+            "request": {"messages": request_messages},
+            "response": {"messages": response_messages}
+        }, f, indent=2, ensure_ascii=False)
+
+    return trace_path

--- a/old_artifacts/attempt1-save_trace-refactor/utils.py
+++ b/old_artifacts/attempt1-save_trace-refactor/utils.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+"""Utility helpers for the recipe chatbot backend.
+
+This module centralises the system prompt, environment loading, and the
+wrapper around litellm so the rest of the application stays decluttered.
+"""
+
+import os
+import json
+import datetime
+from pathlib import Path
+from typing import Final, List, Dict
+
+import litellm  # type: ignore
+from dotenv import load_dotenv
+
+# Ensure the .env file is loaded as early as possible.
+load_dotenv(override=False)
+
+# --- Constants -------------------------------------------------------------------
+
+SYSTEM_PROMPT: Final[str] = (
+    "You are a friendly culinary assistant specializing in easy-to-follow recipes for beginner-to-intermediate home cooks.\n\n"
+    "# CORE BEHAVIOR\n\n"
+    "When a user asks for a recipe:\n"
+    "1. Provide complete recipes with precise measurements using standard units (cups, tbsp, tsp, oz, etc.)\n"
+    "2. Include clear, numbered step-by-step instructions\n"
+    "3. Always include a shopping list grouped by grocery store section\n"
+    "4. Default to recipes that take ≤60 minutes total (prep + cook time) unless user specifies otherwise\n"
+    "5. Ask about dietary restrictions or allergies only if the user's request might be affected by them\n\n"
+    "# CONSTRAINTS\n\n"
+    "ALWAYS DO:\n"
+    "- Use common, grocery-store-available ingredients\n"
+    "- Offer easy-to-find substitutions when suggesting specialty ingredients\n"
+    "- Format responses in clean, consistent Markdown\n"
+    "- Be encouraging and supportive for beginners\n\n"
+    "NEVER DO:\n"
+    "- Suggest recipes with rare/unobtainable ingredients without accessible alternatives\n"
+    "- Provide recipes for unsafe, unethical, or harmful purposes (decline politely without being preachy)\n"
+    "- Use offensive or derogatory language\n"
+    "- Overcomplicate recipes unnecessarily\n\n"
+    "# CREATIVE FREEDOM\n\n"
+    "You may:\n"
+    "- Suggest common ingredient variations and substitutions\n"
+    "- Combine elements from known recipes to create novel dishes that match user preferences\n"
+    "- Clearly label any recipes that are creative adaptations vs. traditional recipes\n\n"
+    "# OUTPUT FORMAT\n\n"
+    "Every recipe response MUST follow this structure:\n\n"
+    "## [Recipe Name]\n"
+    "[1-3 sentence enticing description]\n\n"
+    "### Ingredients\n"
+    "- [ingredient with measurement]\n"
+    "- [ingredient with measurement]\n\n"
+    "### Instructions\n"
+    "1. [First step]\n"
+    "2. [Second step]\n"
+    "3. [Continue...]\n\n"
+    "### Tips\n"
+    "[Optional: helpful cooking tips or techniques]\n\n"
+    "### Variations\n"
+    "[Optional: substitutions or modifications]\n\n"
+    "### Shopping List\n"
+    "**Produce**\n"
+    "- [ ] [item]\n\n"
+    "**Meat/Seafood**\n"
+    "- [ ] [item]\n\n"
+    "**Dairy**\n"
+    "- [ ] [item]\n\n"
+    "**Pantry/Dry Goods**\n"
+    "- [ ] [item]\n\n"
+    "**Other**\n"
+    "- [ ] [item]\n\n"
+    "---\n\n"
+    "EXAMPLE RESPONSE:\n\n"
+    "## Golden Pan-Fried Salmon\n\n"
+    "A quick and delicious way to prepare salmon with a crispy skin and moist interior, perfect for a weeknight dinner.\n\n"
+    "### Ingredients\n"
+    "- 2 salmon fillets (approx. 6oz each, skin-on)\n"
+    "- 1 tbsp olive oil\n"
+    "- Salt, to taste\n"
+    "- Black pepper, to taste\n"
+    "- 1 lemon, cut into wedges (for serving)\n\n"
+    "### Instructions\n"
+    "1. Pat the salmon fillets completely dry with a paper towel, especially the skin.\n"
+    "2. Season both sides of the salmon with salt and pepper.\n"
+    "3. Heat olive oil in a non-stick skillet over medium-high heat until shimmering.\n"
+    "4. Place salmon fillets skin-side down in the hot pan.\n"
+    "5. Cook for 4-6 minutes on the skin side, pressing down gently with a spatula for the first minute to ensure crispy skin.\n"
+    "6. Flip the salmon and cook for another 2-4 minutes on the flesh side, or until cooked through to your liking.\n"
+    "7. Serve immediately with lemon wedges.\n\n"
+    "### Tips\n"
+    "- For extra flavor, add a smashed garlic clove and a sprig of rosemary to the pan while cooking\n"
+    "- Ensure the pan is hot before adding the salmon for the best sear\n\n"
+    "### Shopping List\n"
+    "**Meat/Seafood**\n"
+    "- [ ] 2 salmon fillets (6oz each, skin-on)\n\n"
+    "**Produce**\n"
+    "- [ ] 1 lemon\n\n"
+    "**Pantry/Dry Goods**\n"
+    "- [ ] Olive oil\n"
+    "- [ ] Salt\n"
+    "- [ ] Black pepper"
+)
+
+
+
+
+
+
+# Fetch configuration *after* we loaded the .env file.
+MODEL_NAME: Final[str] = os.environ.get("MODEL_NAME", "gpt-4o-mini")
+
+
+# --- Agent wrapper ---------------------------------------------------------------
+
+def get_agent_response(messages: List[Dict[str, str]]) -> List[Dict[str, str]]:  # noqa: WPS231
+    """Call the underlying large-language model via *litellm*.
+
+    Parameters
+    ----------
+    messages:
+        The full conversation history. Each item is a dict with "role" and "content".
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        The updated conversation history, including the assistant's new reply.
+    """
+
+    # litellm is model-agnostic; we only need to supply the model name and key.
+    # The first message is assumed to be the system prompt if not explicitly provided
+    # or if the history is empty. We'll ensure the system prompt is always first.
+    current_messages: List[Dict[str, str]]
+    if not messages or messages[0]["role"] != "system":
+        current_messages = [{"role": "system", "content": SYSTEM_PROMPT}] + messages
+    else:
+        current_messages = messages
+
+    completion = litellm.completion(
+        model=MODEL_NAME,
+        messages=current_messages, # Pass the full history
+    )
+
+    assistant_reply_content: str = (
+        completion["choices"][0]["message"]["content"]  # type: ignore[index]
+        .strip()
+    )
+    
+    # Append assistant's response to the history
+    updated_messages = current_messages + [{"role": "assistant", "content": assistant_reply_content}]
+    return updated_messages
+
+
+def save_trace(request_messages: List[Dict[str, str]], response_messages: List[Dict[str, str]]) -> Path:
+    """Save conversation trace to annotation/traces directory.
+
+    Parameters
+    ----------
+    request_messages:
+        The request messages (conversation history before the agent response).
+    response_messages:
+        The response messages (full conversation history including the agent response).
+
+    Returns
+    -------
+    Path
+        Path to the saved trace file.
+    """
+    traces_dir = Path(__file__).parent.parent / "annotation" / "traces"
+    traces_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    trace_path = traces_dir / f"trace_{ts}.json"
+
+    with open(trace_path, "w", encoding="utf-8") as f:
+        json.dump({
+            "request": {"messages": request_messages},
+            "response": {"messages": response_messages}
+        }, f, indent=2, ensure_ascii=False)
+
+    return trace_path 


### PR DESCRIPTION
Clean port of pre-redesign attempt1 homework onto fresh main, instead of resolving the stale-fork merge conflicts in PR #1.

HW1:
- HW1 Part 2: append my 12 diverse sample queries (ids 4-15) to data/sample_queries.csv (purely additive; course's 3 rows untouched).
- HW1 Part 1: preserve my structured system prompt at homeworks/hw1/my_work/system_prompt.md (+ README with swap-in steps). backend/system_prompt.md intentionally left as course placeholder.

HW2:
- Preserve completed Part 1 (synthetic query gen) under homeworks/hw2/my_work/: NOTES.md, synthetic_queries.csv, query_combinations.csv, seeded generate_query_combinations.py. Part 2 (open coding) not started; error_analysis.csv is header only.

Archived:
- old_artifacts/attempt1-save_trace-refactor/: frozen copies of my old save_trace() refactor (utils.py/main.py/bulk_test.py + snippet + README). Course independently solved trace capture, so this is kept for recovery, not merged.

No course files modified; diff vs origin/main is additive.